### PR TITLE
Bump roomVersion from 2.6.1 to 2.7.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ lsposed = "1.9.2"
 dokka = "1.9.20"
 
 # Room Database (version)
-roomVersion = "2.6.1"
+roomVersion = "2.7.2"
 
 # OkHttp (additional)
 okhttp-core = "5.1.0"


### PR DESCRIPTION
Bumps `roomVersion` from 2.6.1 to 2.7.2.

Updates `androidx.room:room-runtime` from 2.6.1 to 2.7.2

Updates `androidx.room:room-compiler` from 2.6.1 to 2.7.2

Updates `androidx.room:room-ktx` from 2.6.1 to 2.7.2

---
updated-dependencies:
- dependency-name: androidx.room:room-runtime dependency-version: 2.7.2 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.room:room-compiler dependency-version: 2.7.2 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.room:room-ktx dependency-version: 2.7.2 dependency-type: direct:production update-type: version-update:semver-minor ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Room Database dependency to version 2.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->