### PR TITLE
Bump accompanist from 0.34.0 to 0.36.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ roomVersion = "2.6.1"
 okhttp-core = "5.1.0"
 
 # Accompanist
-accompanist = "0.34.0"
+accompanist = "0.36.0"
 
 # Memory Leak Detection
 leakcanary = "2.14"


### PR DESCRIPTION
Bumps `accompanist` from 0.34.0 to 0.36.0.

Updates `com.google.accompanist:accompanist-systemuicontroller` from 0.34.0 to 0.36.0
- [Release notes](https://github.com/google/accompanist/releases)
- [Commits](https://github.com/google/accompanist/compare/v0.34.0...v0.36.0)

Updates `com.google.accompanist:accompanist-permissions` from 0.34.0 to 0.36.0
- [Release notes](https://github.com/google/accompanist/releases)
- [Commits](https://github.com/google/accompanist/compare/v0.34.0...v0.36.0)

Updates `com.google.accompanist:accompanist-navigation-animation` from 0.34.0 to 0.36.0
- [Release notes](https://github.com/google/accompanist/releases)
- [Commits](https://github.com/google/accompanist/compare/v0.34.0...v0.36.0)

---
updated-dependencies:
- dependency-name: com.google.accompanist:accompanist-systemuicontroller dependency-version: 0.36.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: com.google.accompanist:accompanist-permissions dependency-version: 0.36.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: com.google.accompanist:accompanist-navigation-animation dependency-version: 0.36.0 dependency-type: direct:production update-type: version-update:semver-minor ...