### PR TITLE
Bump dokka from 1.9.20 to 2.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ ndk = "26.2.11394342"
 # Documentation and System
 yuki = "2.0.1"
 lsposed = "1.9.2"
-dokka = "1.9.20"
+dokka = "2.0.0"
 
 # Room Database (version)
 roomVersion = "2.6.1"


### PR DESCRIPTION
Bumps `dokka` from 1.9.20 to 2.0.0.

Updates `org.jetbrains.dokka:dokka-core` from 1.9.20 to 2.0.0
- [Release notes](https://github.com/Kotlin/dokka/releases)
- [Commits](https://github.com/Kotlin/dokka/compare/v1.9.20...v2.0.0)

Updates `org.jetbrains.dokka` from 1.9.20 to 2.0.0
- [Release notes](https://github.com/Kotlin/dokka/releases)
- [Commits](https://github.com/Kotlin/dokka/compare/v1.9.20...v2.0.0)

---
updated-dependencies:
- dependency-name: org.jetbrains.dokka:dokka-core dependency-version: 2.0.0 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.jetbrains.dokka dependency-version: 2.0.0 dependency-type: direct:production update-type: version-update:semver-major ...